### PR TITLE
Add bool comparer to fc::variant::operator==. Fixes #2

### DIFF
--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -823,6 +823,7 @@ string      format_string( const string& format, const variant_object& args )
       if( a.is_int64()   || b.is_int64() )  return a.as_int64() == b.as_int64();
       if( a.is_uint64()  || b.is_uint64() ) return a.as_uint64() == b.as_uint64();
       if( a.is_array()   || b.is_array() )  return a.get_array() == b.get_array();
+      if( a.is_bool()    || b.is_bool() )   return a.as_bool() == b.as_bool();
       return false;
    }
 


### PR DESCRIPTION
Required for `golos.ctrl` tests in GolosChain/golos-smart#195