### PR TITLE
Set default json parser to legacy. #26

### DIFF
--- a/include/fc/io/json.hpp
+++ b/include/fc/io/json.hpp
@@ -22,7 +22,7 @@ namespace fc
             strict_parser         = 1,
             relaxed_parser        = 2,
             legacy_parser_with_string_doubles = 3,
-            default_parser        = relaxed_parser,
+            default_parser        = legacy_parser,
          };
          enum output_formatting
          {


### PR DESCRIPTION
As an part of #26 - set default json parser to legacy.

Resolve #27 - add converter from tuple to variant 