### PR TITLE
Partial compare variants #32

### DIFF
--- a/include/fc/variant.hpp
+++ b/include/fc/variant.hpp
@@ -411,6 +411,9 @@ namespace fc
         explicit variant( const T& val );
 
         void clear();
+
+        bool has_value(const variant&) const;
+
       private:
 
         uint64_t to_uint64() const;

--- a/include/fc/variant_object.hpp
+++ b/include/fc/variant_object.hpp
@@ -95,6 +95,8 @@ namespace fc
       bool operator==(const variant_object&) const;
       bool operator==(const mutable_variant_object&) const;
 
+      bool has_value(const variant_object&) const;
+
    private:
       std::shared_ptr< std::vector< entry > > _key_value;
       friend class mutable_variant_object;

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -563,6 +563,27 @@ const variant_object&  variant::get_object() const {
   FC_THROW_EXCEPTION( bad_cast_exception, "Invalid cast from type '${type}' to Object", ("type",get_type()) );
 }
 
+bool variant::has_value(const variant& v) const {
+    if( get_type() != v.get_type() )
+       return false;
+
+    if( is_double() )  return std::abs(as_double() - v.as_double()) < DOUBLE_ACCURACY;
+    if( is_int64() )   return as_int64()      == v.as_int64();
+    if( is_uint64() )  return as_uint64()     == v.as_uint64();
+    if( is_int128() )  return as_int128()     == v.as_int128();
+    if( is_uint128() ) return as_uint128()    == v.as_uint128();
+    if( is_time() )    return as_time_point() == v.as_time_point();
+    if( is_array() )   return get_array()     == v.get_array();
+    if( is_bool() )    return as_bool()       == v.as_bool();
+
+    if( is_object() )  return get_object().has_value(v.get_object());
+
+    if( get_type() == type_id::string_type )  return get_string() == get_string();
+    if( get_type() == type_id::blob_type )    return get_blob()   == get_blob();
+
+    return false;
+}
+
 void from_variant( const variant& var,  variants& vo )
 {
    vo = var.get_array();

--- a/src/variant_object.cpp
+++ b/src/variant_object.cpp
@@ -162,6 +162,18 @@ namespace fc
       return *this;
    }
 
+   bool variant_object::has_value(const variant_object& obj) const {
+      if (size() == 0) return true;
+      if (size() < obj.size()) return false;
+
+      for (auto& e: obj) {
+         auto itr = find(e.key());
+         if (end() == itr) return false;
+         if (itr->value() != e.value()) return false;
+      }
+      return true;
+   }
+
    bool variant_object::operator==(const variant_object& obj) const {
       if (size() != obj.size()) return false;
 


### PR DESCRIPTION
Resolve #32:
Add method `variant::has_value()` to check that `variant` is part of common `object`.