### PR TITLE
Fix linking of pthread #36

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ SET(CMAKE_FIND_LIBRARY_SUFFIXES ".a;.so")
 IF(NOT APPLE)
  # Linux or other unix
  SET(rt_library rt )
+ SET(CMAKE_THREAD_PREFER_PTHREAD TRUE)
  SET(pthread_library pthread)
 ELSE(NOT APPLE)
  ADD_COMPILE_FLAG("-D_GNU_SOURCE")


### PR DESCRIPTION
Resolves #36 

This pull-request - https://github.com/GolosChain/cyberway.fc/pull/35 - introduced a bug: posix thread library used as -lpthread instead of -pthread. This solution has poor platform support. It is not supported in Docker Ubuntu 18.04, what is because Buildkite on Cyberway was broken yesterday.

I tested this fix. It should work after merge to master and restarting buildkites.